### PR TITLE
Fix logging bug and add dependency stubs

### DIFF
--- a/src/aws_agent/core/agent.py
+++ b/src/aws_agent/core/agent.py
@@ -54,28 +54,33 @@ class AWSAgent:
         """
         logger = logging.getLogger('aws_agent')
         logger.setLevel(getattr(logging, self.config.log_level))
-        
-        # Garante que o diretório de logs existe
-        self.config.log_path.parent.mkdir(parents=True, exist_ok=True)
-        
-        # Handler para arquivo
-        file_handler = logging.FileHandler(self.config.log_path)
-        file_handler.setLevel(logging.DEBUG)
-        
-        # Handler para console
-        console_handler = logging.StreamHandler()
-        console_handler.setLevel(getattr(logging, self.config.log_level))
-        
-        # Formatação
-        formatter = logging.Formatter(
-            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-        )
-        file_handler.setFormatter(formatter)
-        console_handler.setFormatter(formatter)
-        
-        logger.addHandler(file_handler)
-        logger.addHandler(console_handler)
-        
+
+        # Evita adicionar múltiplos handlers se o logger já foi configurado
+        if not logger.handlers:
+            # Garante que o diretório de logs existe
+            self.config.log_path.parent.mkdir(parents=True, exist_ok=True)
+
+            # Handler para arquivo
+            file_handler = logging.FileHandler(self.config.log_path)
+            file_handler.setLevel(logging.DEBUG)
+
+            # Handler para console
+            console_handler = logging.StreamHandler()
+            console_handler.setLevel(getattr(logging, self.config.log_level))
+
+            # Formatação
+            formatter = logging.Formatter(
+                '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+            )
+            file_handler.setFormatter(formatter)
+            console_handler.setFormatter(formatter)
+
+            logger.addHandler(file_handler)
+            logger.addHandler(console_handler)
+
+            # Evita propagação duplicada para o root logger
+            logger.propagate = False
+
         return logger
     
     def _register_services(self) -> None:

--- a/tests/src/boto3.py
+++ b/tests/src/boto3.py
@@ -1,0 +1,17 @@
+class Session:
+    def __init__(self, *args, **kwargs):
+        pass
+    def client(self, *args, **kwargs):
+        class Dummy:
+            def __getattr__(self, name):
+                def method(*args, **kwargs):
+                    return {}
+                return method
+        return Dummy()
+    def resource(self, *args, **kwargs):
+        class Dummy:
+            def __getattr__(self, name):
+                def method(*args, **kwargs):
+                    return {}
+                return method
+        return Dummy()

--- a/tests/src/botocore/exceptions.py
+++ b/tests/src/botocore/exceptions.py
@@ -1,0 +1,7 @@
+class ClientError(Exception):
+    def __init__(self, error_response=None, operation_name=None):
+        super().__init__(str(error_response))
+        self.response = error_response or {'Error': {'Code': 'Error', 'Message': 'Client error'}}
+        self.operation_name = operation_name
+class NoCredentialsError(Exception):
+    pass

--- a/tests/src/yaml.py
+++ b/tests/src/yaml.py
@@ -1,0 +1,14 @@
+
+class SafeLoader:
+    pass
+class SafeDumper:
+    pass
+
+def safe_load(stream):
+    return {}
+
+def dump(data, stream=None, **kwargs):
+    if stream is None:
+        return ""
+    else:
+        stream.write("")


### PR DESCRIPTION
## Summary
- fix duplicate logging handlers in AWSAgent
- add minimal stubs for boto3, botocore and yaml so unit tests can import modules

## Testing
- `pytest -q -o addopts='' -m 'unit'` *(fails: ImportError: cannot import name 'field_validator' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_687927c7a5688321a2742a02939eaee4